### PR TITLE
fix(GAT-7254): update urls in example - timing out validating previous ones

### DIFF
--- a/src/__tests__/translate.test.js
+++ b/src/__tests__/translate.test.js
@@ -120,53 +120,53 @@ describe("POST /translate", () => {
         });
     });
 
-    // describe("POST /translate?output_schema=GWDM&output_version=1.0", () => {
-    //     it("should return 200 if unknown metadata translated to GDMV1", async () => {
-    //         const response = await translate(
-    //             sampleMetadata.hdrukv211,
-    //             undefined,
-    //             undefined,
-    //             "GWDM",
-    //             "1.0",
-    //             "1",
-    //             "1",
-    //             sampleMetadata.extra_hdrukv211
-    //         );
-    //         expect(response.status).toBe(200);
-    //     });
-    // });
+    describe("POST /translate?output_schema=GWDM&output_version=1.0", () => {
+        it("should return 200 if unknown metadata translated to GDMV1", async () => {
+            const response = await translate(
+                sampleMetadata.hdrukv211,
+                undefined,
+                undefined,
+                "GWDM",
+                "1.0",
+                "1",
+                "1",
+                sampleMetadata.extra_hdrukv211
+            );
+            expect(response.status).toBe(200);
+        });
+    });
 
-    // describe("POST /translate", () => {
-    //     it("should return 200 if unknown metadata translated to GDMV1 (by default)", async () => {
-    //         const response = await translate(
-    //             sampleMetadata.hdrukv211,
-    //             undefined,
-    //             undefined,
-    //             "GWDM",
-    //             "1.0",
-    //             "1",
-    //             "1",
-    //             sampleMetadata.extra_hdrukv211
-    //         );
-    //         expect(response.status).toBe(200);
-    //     });
-    // });
+    describe("POST /translate", () => {
+        it("should return 200 if unknown metadata translated to GDMV1 (by default)", async () => {
+            const response = await translate(
+                sampleMetadata.hdrukv211,
+                undefined,
+                undefined,
+                "GWDM",
+                "1.0",
+                "1",
+                "1",
+                sampleMetadata.extra_hdrukv211
+            );
+            expect(response.status).toBe(200);
+        });
+    });
 
-    // describe("POST /translate?output_schema=GWDM", () => {
-    //     it("should return 400 because output_schema is given but output_version is unknown", async () => {
-    //         const response = await translate(
-    //             sampleMetadata.hdrukv211,
-    //             undefined,
-    //             undefined,
-    //             "GWDM",
-    //             undefined,
-    //             "1",
-    //             "1",
-    //             sampleMetadata.extra_hdrukv211
-    //         );
-    //         expect(response.status).toBe(400);
-    //     });
-    // });
+    describe("POST /translate?output_schema=GWDM", () => {
+        it("should return 400 because output_schema is given but output_version is unknown", async () => {
+            const response = await translate(
+                sampleMetadata.hdrukv211,
+                undefined,
+                undefined,
+                "GWDM",
+                undefined,
+                "1",
+                "1",
+                sampleMetadata.extra_hdrukv211
+            );
+            expect(response.status).toBe(400);
+        });
+    });
 
     describe("POST /translate", () => {
         it("should return 200 and itself unchanged", async () => {

--- a/src/utils/data/hdrukv211.json
+++ b/src/utils/data/hdrukv211.json
@@ -27,19 +27,19 @@
     "revisions": [
         {
             "version": "1.0.0",
-            "url": "https://d5faf9c6-6c34-46d7-93c4-7706a5436ed9"
+            "url": "https://healthdatagateway.org/dataset/1?version=1.0.0"
         },
         {
             "version": "2.0.0",
-            "url": "https://a7ddefbd-31d9-4703-a738-256e4689f76a"
+            "url": "https://healthdatagateway.org/dataset/1?version=2.0.0"
         },
         {
             "version": "0.0.1",
-            "url": "https://9e798632-442a-427b-8d0e-456f754d28dc"
+            "url": "https://healthdatagateway.org/dataset/1?version=3.0.0"
         },
         {
             "version": "2.1.1",
-            "url": "https://a7ddefbd-31d9-4703-a738-256e4689f76a"
+            "url": "https://healthdatagateway.org/dataset/1?version=4.0.0"
         }
     ],
     "modified": "2021-01-28T14:15:46Z",


### PR DESCRIPTION
https://hdruk.atlassian.net/browse/GAT-7254

Several tests in traser were timing out. This was due to HDR v3.0.0 having a complex regex to validate urls.  Changing the format of the urls in the test data solved the timing out issue.  I will open a follow-up ticket to review and hopefully simplify the regex we use for urls.